### PR TITLE
Reset colorcolumn

### DIFF
--- a/autoload/float_preview.vim
+++ b/autoload/float_preview.vim
@@ -159,6 +159,7 @@ func! s:check(...)
     call nvim_win_set_option(g:float_preview#win, 'number', v:false)
     call nvim_win_set_option(g:float_preview#win, 'relativenumber', v:false)
     call nvim_win_set_option(g:float_preview#win, 'cursorline', v:false)
+    call nvim_win_set_option(g:float_preview#win, 'colorcolumn', '')
 
     silent doautocmd <nomodeline> User FloatPreviewWinOpen
 endfunc


### PR DESCRIPTION
Colorcolumn are displayed in preview window if such option is enabled. This PR removes colorcolumn from preview windows.