### PR TITLE
Reset cursorcolumn

### DIFF
--- a/autoload/float_preview.vim
+++ b/autoload/float_preview.vim
@@ -159,6 +159,7 @@ func! s:check(...)
     call nvim_win_set_option(g:float_preview#win, 'number', v:false)
     call nvim_win_set_option(g:float_preview#win, 'relativenumber', v:false)
     call nvim_win_set_option(g:float_preview#win, 'cursorline', v:false)
+    call nvim_win_set_option(g:float_preview#win, 'cursorcolumn', v:false)
     call nvim_win_set_option(g:float_preview#win, 'colorcolumn', '')
 
     silent doautocmd <nomodeline> User FloatPreviewWinOpen


### PR DESCRIPTION
Preview windows are considered read only, and so there's no need to respect users settings and show `cursorcolumn` and `cursorline`. The later is already suppressed and turned off for the preview window buffer. This patch does the same for `cursorcolumn`.