### PR TITLE
use neovim's lsp_markdown syntax if available

### DIFF
--- a/autoload/float_preview.vim
+++ b/autoload/float_preview.vim
@@ -82,7 +82,11 @@ func! s:check(...)
         " unlisted-buffer & scratch-buffer (nobuflisted, buftype=nofile,
         " bufhidden=hide, noswapfile)
         let s:buf = nvim_create_buf(0, 1)
-        call nvim_buf_set_option(s:buf, 'syntax', 'OFF')
+        if has('nvim-0.5') == 1
+            call nvim_buf_set_option(s:buf, 'syntax', 'lsp_markdown')
+        else
+            call nvim_buf_set_option(s:buf, 'syntax', 'OFF')
+        endif
     endif
     call nvim_buf_set_lines(s:buf, 0, -1, 0, info)
 


### PR DESCRIPTION
neovim has had a separate syntax for lsp markdown since 0.5: https://github.com/neovim/neovim/commit/d49177afd9806f651c0177f9cc68c5a22dba2938